### PR TITLE
Sub Range & selectedYear

### DIFF
--- a/src/components/DatePicker.tsx
+++ b/src/components/DatePicker.tsx
@@ -26,6 +26,7 @@ export interface IRenderCalendarContainerProps {
 
 export interface IDatePickerProps {
   range: [Date, Date]
+  subRange?: [Date, Date]
   selectedDate: [Date, Date]
   onDateChanged: (date: [Date, Date]) => void
   type: 'range' | 'single'
@@ -58,7 +59,6 @@ function DatePicker({
 }: IDatePickerProps) {
   const allDates = createMonths(props.range)
   const cursorMax = Math.max(0, allDates.length - calendarCount)
-
   const [cursor, setCursor] = React.useState(getInitialCursor(cursorMax))
   const slicedDates = allDates.slice(cursor, cursor + calendarCount)
 
@@ -80,6 +80,7 @@ function DatePicker({
   }
 
   function getViewingYear() {
+    if (cursor >= cursorMax) return props.range[1].getFullYear()
     return (
       props.range[0].getFullYear() +
       Math.floor((cursor + props.range[0].getMonth()) / 12)
@@ -173,7 +174,13 @@ function DatePicker({
     return (date: number[], i: number) => {
       const _asUTC = dateToUTC(new Date(date[0], date[1], date[2]))
       const isBeforeMonth = _asUTC < dateToUTC(props.range[0])
+      const isBeforeSubrange = props.subRange
+        ? _asUTC < dateToUTC(props.subRange[0])
+        : false
       const isAfterMonth = _asUTC > dateToUTC(props.range[1])
+      const isAfterSubrange = props.subRange
+        ? _asUTC > dateToUTC(props.subRange[1])
+        : false
       const isSelectedLowerBound = props.selectedDate
         ? _asUTC >= dateToUTC(props.selectedDate[0])
         : false
@@ -182,7 +189,8 @@ function DatePicker({
         : false
 
       const isHidden = month !== date[1]
-      const isDisabled = isBeforeMonth || isAfterMonth
+      const isDisabled =
+        isBeforeMonth || isAfterMonth || isBeforeSubrange || isAfterSubrange
       const isSelected = props.selectedDate
         ? isSelectedLowerBound && isSelectedUpperBound
         : false

--- a/src/components/__tests__/DatePicker.tsx
+++ b/src/components/__tests__/DatePicker.tsx
@@ -441,6 +441,64 @@ describe('DatePicker', () => {
       getByText('Current Year: 2018')
       getByText(/2018-4-1/)
     })
+    it('passes disabled date config with subRange', () => {
+      const { getByText } = render(
+        <DatePicker
+          range={[new Date('2019-01-10'), new Date('2019-12-31')]}
+          selectedDate={[new Date('2019-01-20'), new Date('2019-01-20')]}
+          subRange={[new Date('2019-01-01'), new Date('2019-02-20')]}
+          onDateChanged={jest.fn()}
+          type="range"
+          renderDates={({ dates }) => (
+            <div data-testid="dates-renderprop">
+              {dates.map(({ date, ...rest }) => (
+                <div key={date.join('-')}>
+                  date: {date.join('-')}
+                  {JSON.stringify(rest)}
+                </div>
+              ))}
+            </div>
+          )}
+        />
+      )
+      getByText(content => {
+        const isDisabled = /2019-1-21/.test(content)
+        const isMarkedDisabled = /"isDisabled":true/.test(content)
+        return isDisabled && isMarkedDisabled
+      })
+    })
+    it('correctly detects viewing year at cursorMax', () => {
+      const { getByText } = render(
+        <DatePicker
+          range={[new Date('2018-05-01'), new Date('2019-01-14')]}
+          selectedDate={[new Date('2018-12-24'), new Date('2019-01-12')]}
+          onDateChanged={jest.fn()}
+          type="range"
+          renderYearSelector={({ selectedYear, selectYear }) => (
+            <React.Fragment>
+              <p>Current Year: {selectedYear}</p>
+              <button
+                data-testid="year-select-renderprop"
+                onClick={() => selectYear(2018)}
+              >
+                Set Year to 2018
+              </button>
+              <button
+                data-testid="year-select-renderprop"
+                onClick={() => selectYear(2019)}
+              >
+                Set Year to 2019
+              </button>
+            </React.Fragment>
+          )}
+        />
+      )
+
+      // @Note: Even though the first year in view is 2018,
+      // we are technically at the last cursor, so we should
+      // see the year of the end of the range
+      getByText('Current Year: 2019')
+    })
   })
 })
 


### PR DESCRIPTION
- Fixed bug in selectedYear when the cursor technically still rests on the year before the last date in range.
- Allowed a subRange to further disable dates for whatever reason. It does not affect the "main" range and does not affect the behaviour of the previous/next buttons (Fixes #4).